### PR TITLE
Use the minified esm bundle for the target of the pkg module path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "17.8.3",
   "description": "LazyLoad is a lightweight (2.4 kB) and flexible script that speeds up your web application by deferring the loading of your below-the-fold images, videos and iframes to when they will enter the viewport. It's written in plain \"vanilla\" JavaScript, it leverages the IntersectionObserver API, it supports responsive images, it optimizes your website for slower connections, and can enable native lazy loading.",
   "main": "dist/lazyload.min.js",
-  "module": "dist/lazyload.esm.js",
+  "module": "dist/lazyload.esm.min.js",
   "browser": "dist/lazyload.min.js",
   "typings": "typings/lazyload.d.ts",
   "devDependencies": {


### PR DESCRIPTION
This allows the imported module to be already minified, and if the environment doesn't need any additional transpiling, be used without any processing/bundling. e.g. directly via unpkg