### PR TITLE
Ensures that the module is not 'forced' to be esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm/lazyload.js",
   "browser": "dist/lazyload.min.js",
   "typings": "typings/lazyload.d.ts",
-  "type": "module",
   "sideEffects": false,
   "devDependencies": {
     "@babel/core": "^7.24.3",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -13,16 +13,6 @@ export default [
     input: "src/lazyload.js",
     output: [
       {
-        file: "dist/lazyload.amd.js",
-        format: "amd"
-      },
-      {
-        file: "dist/lazyload.amd.min.js",
-        format: "amd",
-        plugins: [terser(terserOptions)]
-      },
-
-      {
         file: "dist/lazyload.iife.js",
         name: "LazyLoad",
         format: "iife"


### PR DESCRIPTION
in order not to break compatibility like the bundlers who used this module as in the case of TWBS (see #609) in this pr we ensure that the module remains 'agnostic' as it has always been

### HOW?
- Removes the `type: "module"`
- Renames the rollup config file as `.mjs`

#### SideNotes:
- @verlok ask me to remove the AMD module since nowdays isn't anymore useful

close #609